### PR TITLE
Add temp variable

### DIFF
--- a/contracts/Conference.sol
+++ b/contracts/Conference.sol
@@ -217,18 +217,18 @@ contract Conference is GroupAdmin {
         attendanceMaps = _maps;
         ended = true;
         endedAt = now;
-
+        uint _totalAttended = 0;
         // calculate total attended
         for (uint i = 0; i < attendanceMaps.length; i++) {
             uint map = attendanceMaps[i];
             // brian kerninghan bit-counting method - O(log(n))
             while (map != 0) {
                 map &= (map - 1);
-                totalAttended++;
+                _totalAttended++;
             }
         }
         // since maps can contain more bits than there are registrants, we cap the value!
-        totalAttended = totalAttended < registered ? totalAttended : registered;
+        totalAttended = _totalAttended < registered ? _totalAttended : registered;
 
         if (totalAttended > 0) {
             payoutAmount = uint(totalBalance()) / totalAttended;


### PR DESCRIPTION
The current version is incrementing storage in the loop which is as expensive as not using bitmap (or more expensive for smaller participants as you have to loop 256 times anyway).

My change is to introduce temporary variable which is in memory hence a lot cheaper.


Before
```
    2 participants
type             	gasUsed       	gasPrice	1ETH*USD	gasUsed*gasPrice(Ether)	gasUsed*gasPrice(USD)
create   		2760493		1		468		0.002760493		1.291910724
register		111213		1		468		0.000111213		0.052047684
finalize  		1508132		1		468		0.001508132		0.7058057759999999
withdraw		39646		1		468		0.000039646		0.018554328
      ✓ finalize (4555393 gas)
    20 participants
type             	gasUsed       	gasPrice	1ETH*USD	gasUsed*gasPrice(Ether)	gasUsed*gasPrice(USD)
create   		2760493		1		468		0.002760493		1.291910724
register		111213		1		468		0.000111213		0.052047684
finalize  		1508132		1		468		0.001508132		0.7058057759999999
withdraw		39646		1		468		0.000039646		0.018554328
      ✓ finalize (7001755 gas)
    100 participants
type             	gasUsed       	gasPrice	1ETH*USD	gasUsed*gasPrice(Ether)	gasUsed*gasPrice(USD)
create   		2760493		1		468		0.002760493		1.291910724
register		111213		1		468		0.000111213		0.052047684
finalize  		1508132		1		468		0.001508132		0.7058057759999999
withdraw		39646		1		468		0.000039646		0.018554328
      ✓ finalize (17874475 gas)
    200 participants
register 100
type             	gasUsed       	gasPrice	1ETH*USD	gasUsed*gasPrice(Ether)	gasUsed*gasPrice(USD)
create   		2760493		1		468		0.002760493		1.291910724
register		111213		1		468		0.000111213		0.052047684
finalize  		1508132		1		468		0.001508132		0.7058057759999999
withdraw		39646		1		468		0.000039646		0.018554328
      ✓ finalize (31465375 gas)
    300 participants
register 100
register 200
type             	gasUsed       	gasPrice	1ETH*USD	gasUsed*gasPrice(Ether)	gasUsed*gasPrice(USD)
create   		2760557		1		468		0.002760557		1.2919406759999998
register		111213		1		468		0.000111213		0.052047684
finalize  		2887707		1		468		0.002887707		1.351446876
withdraw		39646		1		468		0.000039646		0.018554328
      ✓ finalize (46435864 gas)
```

After
```
    2 participants
type             	gasUsed       	gasPrice	1ETH*USD	gasUsed*gasPrice(Ether)	gasUsed*gasPrice(USD)
create   		2758341		1		468		0.002758341		1.290903588
register		111213		1		468		0.000111213		0.052047684
finalize  		172137		1		468		0.000172137		0.080560116
withdraw		39646		1		468		0.000039646		0.018554328
      ✓ finalize (3217246 gas)
    20 participants
type             	gasUsed       	gasPrice	1ETH*USD	gasUsed*gasPrice(Ether)	gasUsed*gasPrice(USD)
create   		2758341		1		468		0.002758341		1.290903588
register		111213		1		468		0.000111213		0.052047684
finalize  		172137		1		468		0.000172137		0.080560116
withdraw		39646		1		468		0.000039646		0.018554328
      ✓ finalize (5663608 gas)
    100 participants
type             	gasUsed       	gasPrice	1ETH*USD	gasUsed*gasPrice(Ether)	gasUsed*gasPrice(USD)
create   		2758341		1		468		0.002758341		1.290903588
register		111213		1		468		0.000111213		0.052047684
finalize  		172137		1		468		0.000172137		0.080560116
withdraw		39646		1		468		0.000039646		0.018554328
      ✓ finalize (16536328 gas)
    200 participants
register 100
type             	gasUsed       	gasPrice	1ETH*USD	gasUsed*gasPrice(Ether)	gasUsed*gasPrice(USD)
create   		2758341		1		468		0.002758341		1.290903588
register		111213		1		468		0.000111213		0.052047684
finalize  		172137		1		468		0.000172137		0.080560116
withdraw		39646		1		468		0.000039646		0.018554328
      ✓ finalize (30127228 gas)
    300 participants
register 100
register 200
type             	gasUsed       	gasPrice	1ETH*USD	gasUsed*gasPrice(Ether)	gasUsed*gasPrice(USD)
create   		2758405		1		468		0.002758405		1.29093354
register		111213		1		468		0.000111213		0.052047684
finalize  		215904		1		468		0.000215904		0.101043072
withdraw		39646		1		468		0.000039646		0.018554328
       ✓ finalize (43761909 gas)
```