### PR TITLE
Allow owner to change deposit

### DIFF
--- a/contracts/Conference.sol
+++ b/contracts/Conference.sol
@@ -211,6 +211,14 @@ contract Conference is GroupAdmin {
     }
 
     /**
+     * @dev Change the deposit. The owner can change it as long as no one has registered yet.
+     * @param _deposit the amount event.
+     */
+    function changeDeposit(uint256 _deposit) external onlyOwner noOneRegistered{
+        deposit = _deposit;
+    }
+
+    /**
      * @dev Mark participants as attended and enable payouts. The attendance cannot be undone.
      * @param _maps The attendance status of participants represented by uint256 values.
      */

--- a/contracts/Conference.sol
+++ b/contracts/Conference.sol
@@ -212,7 +212,7 @@ contract Conference is GroupAdmin {
 
     /**
      * @dev Change the deposit. The owner can change it as long as no one has registered yet.
-     * @param _deposit the amount event.
+     * @param _deposit the deposit amount for the event.
      */
     function changeDeposit(uint256 _deposit) external onlyOwner noOneRegistered{
         deposit = _deposit;

--- a/test/conference.js
+++ b/test/conference.js
@@ -65,6 +65,29 @@ contract('Conference', function(accounts) {
     })
   })
 
+  describe('on changeDeposit', function(){
+    let newDeposit;
+    beforeEach(async function(){
+      newDeposit = mulBN(deposit, 2)
+    })
+
+    it('owner can change the deposit', async function(){
+      await conference.changeDeposit(newDeposit, {from:owner});
+      await conference.deposit().should.eventually.eq(newDeposit)
+    })
+
+    it('non owner cannot change the deposit', async function(){
+      await conference.changeDeposit(newDeposit, {from:non_owner}).should.be.rejected;
+      await conference.deposit().should.not.eventually.eq(newDeposit)
+    })
+
+    it('cannot change the deposit once someone registered', async function(){
+      await conference.register({value:deposit});
+      await conference.changeDeposit(newDeposit, {from:owner}).should.be.rejected;
+      await conference.deposit().should.not.eventually.eq(newDeposit)
+    })
+  })
+
   describe('on setLimitOfParticipants', function(){
     it('does not allow to register more than the limit', async function(){
       await conference.setLimitOfParticipants(1)
@@ -83,7 +106,6 @@ contract('Conference', function(accounts) {
       await conference.register({from: accounts[1], value:deposit});
 
       await conference.registered().should.eventually.eq(2)
-
       const invalidTransaction = mulBN(deposit, 0.5)
       const beforeAccountBalance = await getBalance(accounts[2])
 

--- a/test/conference.js
+++ b/test/conference.js
@@ -106,6 +106,7 @@ contract('Conference', function(accounts) {
       await conference.register({from: accounts[1], value:deposit});
 
       await conference.registered().should.eventually.eq(2)
+
       const invalidTransaction = mulBN(deposit, 0.5)
       const beforeAccountBalance = await getBalance(accounts[2])
 


### PR DESCRIPTION
This is only available until people RSVP.
No contract event needs to be emitted to sync to db on server side.