### PR TITLE
Fix coverage

### DIFF
--- a/.solcover.js
+++ b/.solcover.js
@@ -2,6 +2,6 @@ module.exports = {
   accounts: 350,
   port: 8555,
   testrpcOptions: '--port 8555 --accounts 350 --defaultBalanceEther 2000000',
-  testCommand: '../node_modules/.bin/babel-node ../node_modules/.bin/truffle test --network coverage test/erc20_conference.js',
+  testCommand: '../node_modules/.bin/babel-node ../node_modules/.bin/truffle test --network coverage',
   skipFiles: ['zeppelin/lifecycle/Destructible.sol','zeppelin/ownership/Ownable.sol']
 };

--- a/contracts/Deployer.sol
+++ b/contracts/Deployer.sol
@@ -1,7 +1,6 @@
 pragma solidity ^0.5.4;
 
 import './zeppelin/lifecycle/Destructible.sol';
-import './ERC20.sol';
 import './DeployerInterface.sol';
 
 /**

--- a/contracts/ERC20Conference.sol
+++ b/contracts/ERC20Conference.sol
@@ -1,11 +1,11 @@
 pragma solidity ^0.5.4;
 
 import './AbstractConference.sol';
-import './ERC20.sol';
+import 'openzeppelin-solidity/contracts/token/ERC20/IERC20.sol';
 
 contract ERC20Conference is AbstractConference {
 
-    ERC20 public token; // @todo use a safe transfer proxy
+    IERC20 public token; // @todo use a safe transfer proxy
 
     constructor(
         string memory _name,
@@ -19,7 +19,7 @@ contract ERC20Conference is AbstractConference {
         public
     {
         require(_tokenAddress != address(0), 'token address is not set');
-        token = ERC20(_tokenAddress);
+        token = IERC20(_tokenAddress);
     }
 
     /**

--- a/test/behaviors/conference.behavior.js
+++ b/test/behaviors/conference.behavior.js
@@ -131,7 +131,7 @@ function shouldBehaveLikeConference () {
       assert.equal(totalBalance.sub(beforeContractBalance).toString(10), deposit.toString(10))
     })
 
-    it.only('isRegistered for the registered account is true', async function(){
+    it('isRegistered for the registered account is true', async function(){
       console.log(1111)
       expect(2).to.equal(2)
       console.log(1112)
@@ -286,7 +286,7 @@ function shouldBehaveLikeConference () {
       // 1 0 1 1
       // reverse order since we go from right to left in bit parsing:
       // [ 13 (1101) ]
-      
+
       await conference.finalize([13], {from:owner});
       const previousBalance = await getBalance(non_owner);
       const previousContractBalance = await getBalance(conference.address)


### PR DESCRIPTION
Hi @makoto, opening this to see if it resolves your question from the solidity-coverage gitter. 

This (probably) won't make sense but the problem on the `spike-dai` branch is that there are two contracts in the inheritance chain with the same name (`ERC20`). It causes the coverage tool's preparatory compilation work to be undone by truffle when it runs the tests. 

PR
+ replaces references to `contracts/ERC20.sol` with Zeppelin's IERC20
+ unskips the tests

Don't know if this is the correct solution for you ... please feel free to close if not and lmk if there's something different to fix. 