### PR TITLE
Powerful admin

### DIFF
--- a/contracts/AbstractConference.sol
+++ b/contracts/AbstractConference.sol
@@ -146,7 +146,7 @@ contract AbstractConference is Conference, GroupAdmin {
     /**
      * @dev Cancels the event by owner. When the event is canceled each participant can withdraw their deposit back.
      */
-    function cancel() external onlyOwner onlyActive{
+    function cancel() external onlyAdmin onlyActive{
         payoutAmount = deposit;
         cancelled = true;
         ended = true;
@@ -157,7 +157,7 @@ contract AbstractConference is Conference, GroupAdmin {
     /**
     * @dev The event owner transfer the outstanding deposits  if there are any unclaimed deposits after cooling period
     */
-    function clear() external onlyOwner onlyEnded{
+    function clear() external onlyAdmin onlyEnded{
         require(now > endedAt + coolingPeriod, 'still in cooling period');
         uint256 leftOver = totalBalance();
         doWithdraw(owner, leftOver);
@@ -168,7 +168,7 @@ contract AbstractConference is Conference, GroupAdmin {
      * @dev Change the capacity of the event. The owner can change it until event is over.
      * @param _limitOfParticipants the number of the capacity of the event.
      */
-    function setLimitOfParticipants(uint256 _limitOfParticipants) external onlyOwner onlyActive{
+    function setLimitOfParticipants(uint256 _limitOfParticipants) external onlyAdmin onlyActive{
         limitOfParticipants = _limitOfParticipants;
 
         emit UpdateParticipantLimit(limitOfParticipants);
@@ -178,7 +178,7 @@ contract AbstractConference is Conference, GroupAdmin {
      * @dev Change the name of the event. The owner can change it as long as no one has registered yet.
      * @param _name the name of the event.
      */
-    function changeName(string calldata _name) external onlyOwner noOneRegistered{
+    function changeName(string calldata _name) external onlyAdmin noOneRegistered{
         name = _name;
     }
 
@@ -186,7 +186,7 @@ contract AbstractConference is Conference, GroupAdmin {
      * @dev Change the deposit. The owner can change it as long as no one has registered yet.
      * @param _deposit the deposit amount for the event.
      */
-    function changeDeposit(uint256 _deposit) external onlyOwner noOneRegistered{
+    function changeDeposit(uint256 _deposit) external onlyAdmin noOneRegistered{
         deposit = _deposit;
     }
 

--- a/contracts/GroupAdmin.sol
+++ b/contracts/GroupAdmin.sol
@@ -20,7 +20,7 @@ contract GroupAdmin is Ownable {
     * @dev Grants admin right to given addresses.
     * @param newAdmins An array of addresses
     */
-    function grant(address[] memory newAdmins) public onlyOwner{
+    function grant(address[] memory newAdmins) public onlyAdmin{
         for(uint i = 0; i < newAdmins.length; i++){
             admins.push(newAdmins[i]);
             emit AdminGranted(newAdmins[i]);
@@ -31,7 +31,7 @@ contract GroupAdmin is Ownable {
     * @dev Revoke admin right from given addresses.
     * @param oldAdmins An array of addresses
     */
-    function revoke(address[] memory oldAdmins) public onlyOwner{
+    function revoke(address[] memory oldAdmins) public onlyAdmin{
         for(uint oldIdx = 0; oldIdx < oldAdmins.length; oldIdx++){
             for (uint idx = 0; idx < admins.length; idx++) {
                 if (admins[idx] == oldAdmins[oldIdx]) {

--- a/test/group_admin.js
+++ b/test/group_admin.js
@@ -25,9 +25,16 @@ contract('GroupAdmin', function(accounts) {
             assert.strictEqual(await admin.isAdmin.call(non_operator), false);
         })
 
+        it('can be added by operator', async function(){
+            await admin.grant([operator], {from:owner});
+            await admin.grant([another_operator], {from:operator});
+            assert.strictEqual(await admin.isAdmin.call(operator), true);
+            assert.strictEqual(await admin.isAdmin.call(operator), true);
+        })
+
         it('cannot be added by non owner', async function(){
-            await admin.grant([operator], {from:operator}).catch(function(){});
-            assert.strictEqual(await admin.isAdmin.call(operator), false);
+            await admin.grant([operator], {from:non_operator}).catch(function(){});
+            assert.strictEqual(await admin.isAdmin.call(non_operator), false);
         })
     })
 
@@ -48,10 +55,16 @@ contract('GroupAdmin', function(accounts) {
             assert.strictEqual((await admin.numOfAdmins.call()).toNumber(), 1);
         })
 
-        it('cannot be revoked by non owner', async function(){
-            await admin.revoke([operator], {from:operator}).catch(function(){});
+        it('cannot be revoked by non operator', async function(){
+            await admin.revoke([operator], {from:non_operator}).catch(function(){});
             assert.strictEqual(await admin.isAdmin.call(operator), true);
         })
+
+        it('can be revoked by operator', async function(){
+            await admin.revoke([operator], {from:operator});
+            assert.strictEqual(await admin.isAdmin.call(operator), false);
+        })
+
     })
 
     describe('admins', async function(){

--- a/test/group_admin.js
+++ b/test/group_admin.js
@@ -32,7 +32,7 @@ contract('GroupAdmin', function(accounts) {
             assert.strictEqual(await admin.isAdmin.call(operator), true);
         })
 
-        it('cannot be added by non owner', async function(){
+        it('cannot be added by non operator', async function(){
             await admin.grant([operator], {from:non_operator}).catch(function(){});
             assert.strictEqual(await admin.isAdmin.call(non_operator), false);
         })

--- a/test/group_admin.js
+++ b/test/group_admin.js
@@ -67,6 +67,27 @@ contract('GroupAdmin', function(accounts) {
 
     })
 
+    describe('on transferOwnership', function(){
+        beforeEach(async function(){
+            await admin.grant([operator, another_operator, one_more_operator], {from:owner});
+            assert.strictEqual(await admin.isAdmin.call(operator), true);
+            assert.strictEqual(await admin.isAdmin.call(another_operator), true);
+            assert.strictEqual(await admin.isAdmin.call(one_more_operator), true);
+            assert.strictEqual(await admin.owner.call(), owner);
+            assert.strictEqual((await admin.numOfAdmins.call()).toNumber(), 3);
+        })
+
+        it('admins cannot transfer ownership', async function(){
+            await admin.transferOwnership(operator, {from:operator}).catch(function(){});
+            assert.strictEqual(await admin.owner.call(), owner);
+        })
+
+        it('owner can transfer ownership', async function(){
+            await admin.transferOwnership(operator, {from:owner}).catch(function(){});
+            assert.strictEqual(await admin.owner.call(), operator);
+        })
+    })
+
     describe('admins', async function(){
         it('list number of admins', async function(){
             await admin.grant([operator], {from:owner})


### PR DESCRIPTION
This change enable admins to be as powerful as the contract owner.
The only things admins cannot do are now to transferOwnership and destroy the deployer contract