### PR TITLE
clearAndSend function - Send commitment back to Attendees. [solves #42]

### DIFF
--- a/contracts/AbstractConference.sol
+++ b/contracts/AbstractConference.sol
@@ -21,8 +21,8 @@ contract AbstractConference is Conference, GroupAdmin {
     uint256[] public attendanceMaps;
 
     uint256 public clearFee;
-    uint256 lastSent = 0;
-    uint256 withdrawn = 0;
+    uint256 public lastSent = 0;
+    uint256 public withdrawn = 0;
 
     mapping (address => Participant) public participants;
     mapping (uint256 => address) public participantsIndex;
@@ -172,7 +172,7 @@ contract AbstractConference is Conference, GroupAdmin {
     }
 
     /**
-    * @dev The event owner transfer the outstanding deposits  if there are any unclaimed deposits after cooling period
+    * @dev The event owner transfer the outstanding deposits if there are any unclaimed deposits after cooling period
     */
     function clear() external onlyAdmin onlyEnded afterCoolingPeriod {        
         uint256 leftOver = totalBalance();
@@ -195,7 +195,6 @@ contract AbstractConference is Conference, GroupAdmin {
     * Fees are aggregated and sent to msg.sender.
     */
     function clearAndSend(uint256 _num) external onlyEnded afterCoolingPeriod {
-        require(_num > 0 && _num <= totalAttended, 'Wrong number of withdrawals');
         _clearAndSend(_num);
     }
 
@@ -265,6 +264,10 @@ contract AbstractConference is Conference, GroupAdmin {
     */ 
     function _clearAndSend(uint256 _num) internal onlyEnded afterCoolingPeriod {
         require(withdrawn < totalAttended, 'No more users to clear!');
+
+        uint256 remain = totalAttended - withdrawn;
+        _num = (_num < remain) ? _num : remain;
+
         uint256 fee = payoutAmount.mul(clearFee).div(1000);
         uint256 toAttenders = payoutAmount.sub(fee);
 

--- a/contracts/AbstractConference.sol
+++ b/contracts/AbstractConference.sol
@@ -174,7 +174,8 @@ contract AbstractConference is Conference, GroupAdmin {
     /**
     * @dev The event owner transfer the outstanding deposits if there are any unclaimed deposits after cooling period
     */
-    function clear() external onlyAdmin onlyEnded afterCoolingPeriod {        
+    function clear() external onlyAdmin onlyEnded afterCoolingPeriod {  
+        require(withdrawn == totalAttended, 'You can clear the contract only when everybody withdraw!');      
         uint256 leftOver = totalBalance();
         doWithdraw(owner, leftOver);
         emit ClearEvent(owner, leftOver);

--- a/contracts/AbstractConference.sol
+++ b/contracts/AbstractConference.sol
@@ -174,8 +174,8 @@ contract AbstractConference is Conference, GroupAdmin {
     /**
     * @dev The event owner transfer the outstanding deposits if there are any unclaimed deposits after cooling period
     */
-    function clear() external onlyAdmin onlyEnded afterCoolingPeriod {  
-        require(withdrawn == totalAttended, 'You can clear the contract only when everybody withdraw!');      
+    function clear() external onlyAdmin onlyEnded afterCoolingPeriod {
+        require(withdrawn == totalAttended, 'You can clear the contract only when everybody withdraw!');
         uint256 leftOver = totalBalance();
         doWithdraw(owner, leftOver);
         emit ClearEvent(owner, leftOver);

--- a/contracts/AbstractConference.sol
+++ b/contracts/AbstractConference.sol
@@ -269,8 +269,7 @@ contract AbstractConference is Conference, GroupAdmin {
         uint256 toAttenders = payoutAmount.sub(fee);
 
         uint256 totalSent = 0;
-        address payable pAddress;
-        for(uint j = lastSent.div(256); totalSent < _num && j < attendanceMaps.length; j++) {
+        for(uint256 j = lastSent.div(256); totalSent < _num && j < attendanceMaps.length; j++) {
             uint256 map = attendanceMaps[j];
             for(uint256 i = 0; totalSent < _num && i < 256; i++) {
                 Participant storage participant = participants[participantsIndex[(j.mul(256).add(i).add(1))]];

--- a/contracts/Conference.sol
+++ b/contracts/Conference.sol
@@ -10,6 +10,7 @@ interface Conference {
     event RegisterEvent(address addr, uint256 index);
     event FinalizeEvent(uint256[] maps, uint256 payout, uint256 endedAt);
     event WithdrawEvent(address addr, uint256 payout);
+    event SendAndWithdraw(address payable[] addresses, uint256[] values, address addr, uint256 payoutLeft);
     event CancelEvent(uint256 endedAt);
     event ClearEvent(address addr, uint256 leftOver);
     event UpdateParticipantLimit(uint256 limit);
@@ -47,6 +48,7 @@ interface Conference {
     // AbstractConference
     function register() external payable;
     function withdraw() external;
+    function sendAndWithdraw(address payable[] calldata, uint256[] calldata) external;
     function totalBalance() view external returns (uint256);
     function isRegistered(address _addr) view external returns (bool);
     function isAttended(address _addr) external view returns (bool);

--- a/contracts/Conference.sol
+++ b/contracts/Conference.sol
@@ -12,7 +12,6 @@ interface Conference {
     event WithdrawEvent(address addr, uint256 payout);
     event CancelEvent(uint256 endedAt);
     event ClearEvent(address addr, uint256 leftOver);
-    event ClearAndSend(address payable[] addresses, uint256 value, address payable sender, uint256 fee);
     event UpdateParticipantLimit(uint256 limit);
 
     // Variables

--- a/contracts/Conference.sol
+++ b/contracts/Conference.sol
@@ -12,6 +12,7 @@ interface Conference {
     event WithdrawEvent(address addr, uint256 payout);
     event CancelEvent(uint256 endedAt);
     event ClearEvent(address addr, uint256 leftOver);
+    event ClearAndSend(address payable[] addresses, uint256 value, address payable sender, uint256 fee);
     event UpdateParticipantLimit(uint256 limit);
 
     // Variables
@@ -53,6 +54,8 @@ interface Conference {
     function isPaid(address _addr) external view returns (bool);
     function cancel() external;
     function clear() external;
+    function clearAndSend() external;
+    function clearAndSend(uint256 _num) external;
     function setLimitOfParticipants(uint256 _limitOfParticipants) external;
     function changeName(string calldata _name) external;
     function changeDeposit(uint256 _deposit) external;

--- a/contracts/Deployer.sol
+++ b/contracts/Deployer.sol
@@ -36,7 +36,8 @@ contract Deployer is Destructible {
         uint256 _deposit,
         uint _limitOfParticipants,
         uint _coolingPeriod,
-        address _tokenAddress
+        address _tokenAddress,
+        uint256 _clearFee
     ) external {
         Conference c;
         if(_tokenAddress != address(0)){
@@ -46,7 +47,8 @@ contract Deployer is Destructible {
                 _limitOfParticipants,
                 _coolingPeriod,
                 msg.sender,
-                _tokenAddress
+                _tokenAddress,
+                _clearFee
             );
         }else{
             c = ethDeployer.deploy(
@@ -55,7 +57,8 @@ contract Deployer is Destructible {
                 _limitOfParticipants,
                 _coolingPeriod,
                 msg.sender,
-                address(0)
+                address(0),
+                _clearFee
             );
         }
         emit NewParty(address(c), msg.sender);

--- a/contracts/DeployerInterface.sol
+++ b/contracts/DeployerInterface.sol
@@ -8,6 +8,7 @@ interface DeployerInterface {
         uint _limitOfParticipants,
         uint _coolingPeriod,
         address payable _ownerAddress,
-        address _tokenAddress
+        address _tokenAddress,
+        uint256 _clearFee
     )external returns(Conference c);
 }

--- a/contracts/ERC20Conference.sol
+++ b/contracts/ERC20Conference.sol
@@ -13,9 +13,10 @@ contract ERC20Conference is AbstractConference {
         uint256 _limitOfParticipants,
         uint256 _coolingPeriod,
         address payable _owner,
-        address  _tokenAddress
+        address  _tokenAddress,
+        uint256 _clearFee
     )
-        AbstractConference(_name, _deposit, _limitOfParticipants, _coolingPeriod, _owner)
+        AbstractConference(_name, _deposit, _limitOfParticipants, _coolingPeriod, _owner, _clearFee)
         public
     {
         require(_tokenAddress != address(0), 'token address is not set');

--- a/contracts/ERC20Deployer.sol
+++ b/contracts/ERC20Deployer.sol
@@ -10,7 +10,8 @@ contract ERC20Deployer is DeployerInterface{
         uint _limitOfParticipants,
         uint _coolingPeriod,
         address payable _ownerAddress,
-        address _tokenAddress
+        address _tokenAddress,
+        uint256 _clearFee
     )external returns(Conference c){
         c = new ERC20Conference(
             _name,
@@ -18,7 +19,8 @@ contract ERC20Deployer is DeployerInterface{
             _limitOfParticipants,
             _coolingPeriod,
             _ownerAddress,
-            _tokenAddress
+            _tokenAddress,
+            _clearFee
         );
     }   
 }

--- a/contracts/EthConference.sol
+++ b/contracts/EthConference.sol
@@ -8,9 +8,10 @@ contract EthConference is AbstractConference {
         uint256 _deposit,
         uint256 _limitOfParticipants,
         uint256 _coolingPeriod,
-        address payable _owner
+        address payable _owner,
+        uint256 _clearFee
     )
-        AbstractConference(_name, _deposit, _limitOfParticipants, _coolingPeriod, _owner)
+        AbstractConference(_name, _deposit, _limitOfParticipants, _coolingPeriod, _owner, _clearFee)
         public
     {
     }

--- a/contracts/EthDeployer.sol
+++ b/contracts/EthDeployer.sol
@@ -10,14 +10,16 @@ contract EthDeployer is DeployerInterface{
         uint _limitOfParticipants,
         uint _coolingPeriod,
         address payable _ownerAddress,
-        address /* _tokenAddress */
+        address /* _tokenAddress */,
+        uint256 _clearFee
     )external returns(Conference c){
         c = new EthConference(
             _name,
             _deposit,
             _limitOfParticipants,
             _coolingPeriod,
-            _ownerAddress
+            _ownerAddress,
+            _clearFee
         );
     }   
 }

--- a/test/behaviors/conference.behavior.js
+++ b/test/behaviors/conference.behavior.js
@@ -647,6 +647,23 @@ function shouldBehaveLikeConference () {
       assertBalanceWithDeposit((await getBalance(conference.address)), mulBN(payoutAmount, 0))
     })
 
+    it('user can withdraw even after clearAndSend is called as long as the user is not withdrawn', async function() {
+      await wait(20, 1);
+      let previousBalanceOne = await getBalance(accounts[11]);
+      let previousBalanceTwo = await getBalance(accounts[12]);
+
+      await conference.clearAndSend(1);
+      await conference.withdraw({from:accounts[11]}).should.be.rejected;
+      await conference.withdraw({from:accounts[12]});
+      
+      let diffOne = new EthVal(await getBalance(accounts[11])).sub(previousBalanceOne)
+      let diffTwo = new EthVal(await getBalance(accounts[12])).sub(previousBalanceTwo)
+      assert.isOk(diffOne.lte(payoutAmount.sub(fees))) // for eth: due to gas
+      assert.isOk(diffTwo.gt(payoutAmount.mul(0.9))) // for eth: due to gas
+      
+      assertBalanceWithDeposit((await getBalance(conference.address)), mulBN(payoutAmount, 0))
+    })
+
   })
 
 };

--- a/test/behaviors/conference.behavior.js
+++ b/test/behaviors/conference.behavior.js
@@ -533,6 +533,28 @@ function shouldBehaveLikeConference () {
       assertBalanceWithDeposit((await getBalance(conference.address)), mulBN(deposit, 0))
     })
   })
+
+/*
+  describe('on clear and send', function(){
+    let conference, deposit, attended, fee;
+
+    beforeEach(async function(){
+      conference = await createConference({})
+      deposit = await conference.deposit()
+      
+      let numRegistered = 4;
+      for (let i = 0; i < numRegistered; ++i) {
+          await register({conference, deposit, user:accounts[10 + i], owner})
+      }
+
+      console.log(payoutAmount, fee);
+    })
+
+    it('owner can change the deposit', async function(){
+
+    })
+  })
+  */
 };
 
 module.exports = {

--- a/test/behaviors/conference.behavior.js
+++ b/test/behaviors/conference.behavior.js
@@ -654,6 +654,12 @@ function shouldBehaveLikeConference () {
 
       await conference.clearAndSend(1);
       await conference.withdraw({from:accounts[11]}).should.be.rejected;
+
+      let paidOne = await conference.isPaid(accounts[11]);
+      let paidTwo = await conference.isPaid(accounts[12]);
+      paidOne.should.eq(true);
+      paidTwo.should.eq(false);
+
       await conference.withdraw({from:accounts[12]});
       
       let diffOne = new EthVal(await getBalance(accounts[11])).sub(previousBalanceOne)

--- a/test/behaviors/conference.behavior.js
+++ b/test/behaviors/conference.behavior.js
@@ -595,10 +595,25 @@ function shouldBehaveLikeConference () {
     })
 
     it('calling with a number of attendees greater than the contract\'s one', async function() {
-      await wait(20, 1);
-      await conference.clearAndSend(5).should.be.rejected;
+      let previousBalanceOne = await getBalance(accounts[11]);
+      let previousBalanceTwo = await getBalance(accounts[12]);
 
-      assertBalanceWithDeposit((await getBalance(conference.address)), mulBN(payoutAmount, 2))
+      await wait(20, 1);
+      await conference.clearAndSend(5);
+
+      let paidOne = await conference.isPaid(accounts[11]);
+      let paidTwo = await conference.isPaid(accounts[12]);
+      paidOne.should.eq(true);
+      paidTwo.should.eq(true);
+
+      let diffOne = new EthVal(await getBalance(accounts[11])).sub(previousBalanceOne)
+      let diffTwo = new EthVal(await getBalance(accounts[12])).sub(previousBalanceTwo)
+      
+      assert.isOk(diffOne.eq(payoutAmount.sub(fees)))
+      assert.isOk(diffTwo.eq(payoutAmount.sub(fees)))
+
+
+      assertBalanceWithDeposit((await getBalance(conference.address)), mulBN(payoutAmount, 0))
     })
 
     it('consecutive calls', async function() {

--- a/test/behaviors/conference.behavior.js
+++ b/test/behaviors/conference.behavior.js
@@ -466,6 +466,71 @@ function shouldBehaveLikeConference () {
     })
   })
 
+  describe('on send and withdraw', function(){
+    let conference, deposit, registered, donation, donationTwo;
+    beforeEach(async function(){
+      conference = await createConference({});
+      deposit = await conference.deposit(); // should be 0.02 ether (2*10e16 wei)
+      registered = accounts[1];
+      donation = toWei('0.01', "ether");
+      donationTwo = toWei('0.005', "ether");
+
+      await register({conference, deposit, user:owner, owner});
+      await register({conference, deposit, user:registered, owner});
+
+      assertBalanceWithDeposit((await getBalance(conference.address)), mulBN(deposit, 2))
+    })
+
+    it('should take only `deposit` value', async function() {
+      await conference.cancel({from:owner});
+      await conference.sendAndWithdraw([accounts[2]], [donation], {from:registered});
+      assertBalanceWithDeposit((await getBalance(conference.address)), mulBN(deposit, 1))
+    })
+
+    it('more addresses than values or viceversa', async function(){
+      await conference.cancel({from:owner});
+      await conference.sendAndWithdraw([accounts[2]], [donation, donation], {from:registered}).should.be.rejected;
+      assertBalanceWithDeposit((await getBalance(conference.address)), mulBN(deposit, 2))
+    })
+
+    it('payout amount is less than sum of values', async function(){
+      await conference.cancel({from:owner});
+      await conference.sendAndWithdraw([accounts[2]], [toWei('1', "ether")], {from:registered}).should.be.rejected;
+      assertBalanceWithDeposit((await getBalance(conference.address)), mulBN(deposit, 2))
+    })
+
+    it('send and withdraw with empty arrays should send funds to sender', async function(){
+      await conference.cancel({from:owner});
+
+      let previousBalance = await getBalance(registered);
+
+      await conference.sendAndWithdraw([], [], {from:registered});
+      
+      let diff = (await getBalance(registered)).sub(previousBalance);
+      assert.isOk(diff.gt( mulBN(deposit, 0.9) ))
+
+      assertBalanceWithDeposit((await getBalance(conference.address)), mulBN(deposit, 1))
+    })
+
+    it('splits correctly', async function(){
+      await conference.cancel({from:owner});
+
+      let previousBalanceOne = await getBalance(accounts[10]);
+      let previousBalanceTwo = await getBalance(accounts[20]);
+
+      await conference.sendAndWithdraw([accounts[10], accounts[20]], [donation, donationTwo], {from:registered});
+      
+      let diffOne = (await getBalance(accounts[10])).sub(previousBalanceOne);
+      let diffTwo = (await getBalance(accounts[20])).sub(previousBalanceTwo);
+      
+      assert.isOk(diffOne.eq(donation));
+      assert.isOk(diffTwo.eq(donationTwo));
+
+      assertBalanceWithDeposit((await getBalance(conference.address)), mulBN(deposit, 1))
+    })
+
+  })
+
   describe('on clear', function(){
     let conference, deposit, registered, notRegistered
     beforeEach(async function(){

--- a/test/behaviors/conference.behavior.js
+++ b/test/behaviors/conference.behavior.js
@@ -526,7 +526,6 @@ function shouldBehaveLikeConference () {
       await conference.ended().should.eventually.eq(true)
       assertBalanceWithDeposit((await getBalance(conference.address)), mulBN(deposit, 4))
 
-      //let previousBalance = await getBalance(owner);
       await wait(20, 1);
       await conference.clear({from:owner}).should.be.rejected
 

--- a/test/behaviors/conference.behavior.js
+++ b/test/behaviors/conference.behavior.js
@@ -548,6 +548,7 @@ function shouldBehaveLikeConference () {
       // [ 110 ], accounts[11], accounts[12]
       const maps = [ toBN(0).bincn(1).bincn(2) ];
 
+
       await conference.finalize(maps, {from:owner});
       await conference.ended().should.eventually.eq(true)
       
@@ -555,7 +556,7 @@ function shouldBehaveLikeConference () {
       clearFee = await conference.clearFee();
       fees = payoutAmount.mul(clearFee).div(1000).toString(10);
 
-      assertBalanceWithDeposit((await getBalance(conference.address)), mulBN(deposit, 4))
+      assertBalanceWithDeposit((await getBalance(conference.address)), mulBN(deposit, numRegistered))
     })
 
     it('fees calculation works correctly', async function(){
@@ -572,7 +573,7 @@ function shouldBehaveLikeConference () {
 
       assert.isOk(diffOne.eq(payoutAmount.sub(fees)))
       assert.isOk(diffTwo.eq(payoutAmount.sub(fees)))
-      assert.isOk(diffOwner.gt(new EthVal(fees).mul(1.9)))
+      assert.isOk(diffOwner.gt(new EthVal(fees).mul(2).mul(0.9))) // greater than ((fees * 2) * 0.9) due to gas consumption
 
       assertBalanceWithDeposit((await getBalance(conference.address)), 0)
     })
@@ -607,7 +608,8 @@ function shouldBehaveLikeConference () {
       await wait(20, 1);
       await conference.clearAndSend(1);
       await conference.clearAndSend(1);
-      
+      await conference.clearAndSend(1).should.be.rejected;
+
       let diffOne = new EthVal(await getBalance(accounts[11])).sub(previousBalanceOne)
       let diffTwo = new EthVal(await getBalance(accounts[12])).sub(previousBalanceTwo)
       

--- a/test/conference.js
+++ b/test/conference.js
@@ -17,7 +17,7 @@ contract('ETH Conference', function(accounts) {
       limitOfParticipants = 20,
       coolingPeriod = 0,
       ownerAddress = accounts[0],
-      clearFee = 1000,
+      clearFee = 10,
       gasPrice = toWei('1', 'gwei')
     }) => {
       return Conference.new(

--- a/test/conference.js
+++ b/test/conference.js
@@ -17,6 +17,7 @@ contract('ETH Conference', function(accounts) {
       limitOfParticipants = 20,
       coolingPeriod = 0,
       ownerAddress = accounts[0],
+      clearFee = 1000,
       gasPrice = toWei('1', 'gwei')
     }) => {
       return Conference.new(
@@ -24,7 +25,8 @@ contract('ETH Conference', function(accounts) {
         deposit,
         limitOfParticipants,
         coolingPeriod,
-        ownerAddress
+        ownerAddress,
+        clearFee
         , {gasPrice:gasPrice}
       );
     }

--- a/test/deployer.js
+++ b/test/deployer.js
@@ -11,6 +11,7 @@ const Token = artifacts.require("MyToken.sol");
 contract('Deployer', accounts => {
   let deployer, ethDeployer, erc20Deployer;
   let emptyAddress = '0x0000000000000000000000000000000000000000'
+  let clearFee = 1000
   beforeEach(async () => {
     ethDeployer = await EthDeployer.new();
     erc20Deployer = await ERC20Deployer.new();
@@ -39,7 +40,8 @@ contract('Deployer', accounts => {
       toHex(toWei('0.02')),
       toHex(2),
       toHex(60 * 60 * 24 * 7),
-      emptyAddress
+      emptyAddress,
+      clearFee
     )
 
     const events = await getEvents(result, 'NewParty')
@@ -64,7 +66,8 @@ contract('Deployer', accounts => {
       toHex(10),
       toHex(2),
       toHex(60 * 60 * 24 * 7),
-      token.address
+      token.address,
+      clearFee
     )
 
     const events = await getEvents(result, 'NewParty')
@@ -90,7 +93,8 @@ contract('Deployer', accounts => {
       toHex(toWei('0.02')),
       toHex(2),
       toHex(60 * 60 * 24 * 7),
-      emptyAddress
+      emptyAddress,
+      clearFee
     )
 
     const [ { args: { deployedAddress} } ] = (await getEvents(result, 'NewParty'))

--- a/test/deployer.js
+++ b/test/deployer.js
@@ -11,7 +11,7 @@ const Token = artifacts.require("MyToken.sol");
 contract('Deployer', accounts => {
   let deployer, ethDeployer, erc20Deployer;
   let emptyAddress = '0x0000000000000000000000000000000000000000'
-  let clearFee = 1000
+  let clearFee = 10
   beforeEach(async () => {
     ethDeployer = await EthDeployer.new();
     erc20Deployer = await ERC20Deployer.new();

--- a/test/erc20_conference.js
+++ b/test/erc20_conference.js
@@ -20,6 +20,7 @@ contract('ERC20 Conference', function(accounts) {
       coolingPeriod = 0,
       ownerAddress = accounts[0],
       tokenAdderss = token.address,
+      clearFee = 1000,
       gasPrice = toWei('1', 'gwei')
     }) => {
       return Conference.new(
@@ -28,7 +29,8 @@ contract('ERC20 Conference', function(accounts) {
         limitOfParticipants,
         coolingPeriod,
         ownerAddress,
-        tokenAdderss
+        tokenAdderss,
+        clearFee
         , {gasPrice:gasPrice}
       );
     }

--- a/test/erc20_conference.js
+++ b/test/erc20_conference.js
@@ -20,7 +20,7 @@ contract('ERC20 Conference', function(accounts) {
       coolingPeriod = 0,
       ownerAddress = accounts[0],
       tokenAdderss = token.address,
-      clearFee = 1000,
+      clearFee = 10,
       gasPrice = toWei('1', 'gwei')
     }) => {
       return Conference.new(

--- a/test/stress.js
+++ b/test/stress.js
@@ -16,6 +16,7 @@ contract('ETH Conference - stress tests', function(accounts) {
       limitOfParticipants = 20,
       coolingPeriod = 0,
       ownerAddress = accounts[0],
+      clearFee = 1000,
       gasPrice = toWei('1', 'gwei')
     }) => {
       return Conference.new(
@@ -23,7 +24,8 @@ contract('ETH Conference - stress tests', function(accounts) {
         deposit,
         limitOfParticipants,
         coolingPeriod,
-        ownerAddress
+        ownerAddress,
+        clearFee
         , {gasPrice:gasPrice}
       );
     }


### PR DESCRIPTION
Some comments on the approach:

- **Clearing Fees**
   - Clearing fee is denoted by `clearFee` and is set in the constructor through `_clearFee`
   - Clearing fee is expressed in Per Mille notation (‰) and fees can have a precision up to 1 decimal (e.g 1.5%)
   - `_clearFee` passed to the constructor can be calculated as: `PERCENT * 10`

- **`clearAndSend` function**
   The approach used seemed to be more efficient than a straightforward for loop like this:
   ```        
   uint256 i = lastSent;
   uint256 sent = 0;
   address payable pAddress;
   for(; i <= totalAttended; i++) {
      if(sent == _num) break;
      Participant storage participant = participants[participantsIndex[i.add(1)]];
      if(_indexAttended(i) && !participant.paid) {
         participant.paid = true;
         sent = sent.add(1);
         doWithdraw(participant.addr, toAttenders);
      }
   }
   lastSent = i;
   ...
   function _indexAttended(uint256 i) internal view returns(bool) {
         uint256 map = attendanceMaps[uint256(pIndex.div(256))];
         return (0 < (map & (2 ** (pIndex.mod(256)))));
   }
   ```

   In particular running `yarn test` on both implementations the result is (clearing two attendees):
   - for-loop gas consumption: `85822` gas
   - current approach: `83217` gas

   Current approach seems to be ~3% more gas efficient. This is due to the number of accesses to the `attendanceMaps` bitmap.

That's all, hope everything is okay.
   
